### PR TITLE
Fix location of DATA1_18

### DIFF
--- a/Development/EBAZ4205.xdc
+++ b/Development/EBAZ4205.xdc
@@ -22,7 +22,7 @@
 #set_property -dict { PACKAGE_PIN H18   IOSTANDARD LVCMOS33 } [get_ports { DATA1_15 }]; 
 #set_property -dict { PACKAGE_PIN D19   IOSTANDARD LVCMOS33 } [get_ports { DATA1_16 }]; 
 #set_property -dict { PACKAGE_PIN F20   IOSTANDARD LVCMOS33 } [get_ports { DATA1_17 }]; 
-#set_property -dict { PACKAGE_PIN E18   IOSTANDARD LVCMOS33 } [get_ports { DATA1_18 }]; 
+#set_property -dict { PACKAGE_PIN E19   IOSTANDARD LVCMOS33 } [get_ports { DATA1_18 }]; 
 #set_property -dict { PACKAGE_PIN F19   IOSTANDARD LVCMOS33 } [get_ports { DATA1_19 }]; 
 #set_property -dict { PACKAGE_PIN K17   IOSTANDARD LVCMOS33 } [get_ports { DATA1_20 }]; 
 


### PR DESCRIPTION
Hi - I tried using the XDC file in this repo, and found the location of DATA1_18 is incorrect - it should be on pin E19.
![](https://9net.org/screenshots/1620139546.png)